### PR TITLE
Add a Projects page for David Kwagala’s portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
       </a>
       <div class="nav-links" role="navigation" aria-label="Primary navigation">
         <a href="#suite">Suite</a>
-        <a href="#roadmap">Roadmap</a>
+        <a href="/projects.html">Projects</a>
         <a href="/about.html">About</a>
         <a href="/contact.html">Contact</a>
         <a href="https://coxdoj.github.io/Life-in-God-is-Life-in-Love/" class="btn btnPrimary">Join</a>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Projects · CrownWords</title>
+  <meta name="description" content="Explore faith-led tools and projects created by David Kwagala through CrownWords.">
+  <link rel="canonical" href="https://coxdoj.github.io/projects.html">
+  <meta name="theme-color" content="#07070b">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Projects · CrownWords">
+  <meta property="og:description" content="Faith-led tools for Word, wealth, worship, creativity, and practical life.">
+  <meta property="og:url" content="https://coxdoj.github.io/projects.html">
+  <meta property="og:image" content="https://coxdoj.github.io/og-banner.png">
+  <style>
+    :root{--bg0:#07070b;--bg1:#0c0f1a;--fg:#f2f3ff;--muted:#c0c3d9;--accent:#dcbc4c;--accent2:#7fe7ff;--shadow:0 18px 60px rgba(0,0,0,.45)}
+    html{color-scheme:dark}*{box-sizing:border-box}
+    body{margin:0;min-height:100vh;color:var(--fg);font:16px/1.6 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;background:radial-gradient(1400px 700px at 20% 10%,rgba(124,190,255,.18),transparent 60%),radial-gradient(1000px 700px at 80% 10%,rgba(223,186,88,.18),transparent 55%),linear-gradient(180deg,var(--bg0),var(--bg1))}
+    a{color:inherit}.wrap{max-width:980px;margin:0 auto;padding:22px 18px}
+    .skip{position:absolute;left:-9999px}.skip:focus{left:12px;top:12px;z-index:30;background:#000;padding:8px 12px;border-radius:8px}
+    header{position:sticky;top:0;z-index:20;border-bottom:1px solid rgba(255,255,255,.06);backdrop-filter:blur(10px);background:linear-gradient(180deg,rgba(10,10,14,.82),rgba(10,10,14,.62))}
+    nav{display:flex;align-items:center;gap:12px}.brand{display:flex;align-items:center;gap:10px;margin-right:auto;text-decoration:none}.brand strong{letter-spacing:.5px;font-weight:900}
+    .logo{width:34px;height:34px;border-radius:12px;border:1px solid rgba(255,255,255,.22);background:linear-gradient(180deg,rgba(255,255,255,.15),rgba(255,255,255,.03));position:relative;overflow:hidden}.logo:after{content:"";position:absolute;inset:-20px;background:conic-gradient(from 210deg,var(--accent),var(--accent2),var(--accent));filter:blur(18px);opacity:.65}
+    .nav-links{display:flex;gap:10px;align-items:center}.nav-links a{padding:8px 10px;border-radius:10px;border:1px solid transparent}.nav-links a:hover,.nav-links a[aria-current="page"]{border-color:rgba(255,255,255,.12);background:rgba(255,255,255,.03)}
+    .intro{max-width:720px;padding:56px 0 22px}.eyebrow{color:var(--accent2);font-weight:800;letter-spacing:.12em;text-transform:uppercase;font-size:.78rem}.intro h1{font-size:clamp(2.2rem,7vw,4.5rem);line-height:1.05;margin:.35rem 0 1rem}.intro p{color:var(--muted);font-size:1.12rem}
+    .projects{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px;margin-top:22px}.card{padding:24px;border-radius:20px;border:1px solid rgba(255,255,255,.12);background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.02));box-shadow:var(--shadow)}.card h2{margin:0 0 8px;font-size:1.2rem}.card p{margin:0;color:var(--muted)}
+    .principles{margin-top:40px;padding:24px;border-left:3px solid var(--accent);background:rgba(255,255,255,.03);border-radius:0 16px 16px 0}.principles h2{margin-top:0}.principles p{color:var(--muted);margin-bottom:0}
+    footer{margin-top:46px;padding:26px 0;border-top:1px solid rgba(255,255,255,.08);color:var(--muted);font-size:13px}
+    @media(max-width:720px){nav{align-items:flex-start}.nav-links{flex-wrap:wrap;justify-content:flex-end}.projects{grid-template-columns:1fr}.intro{padding-top:38px}}
+  </style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <header>
+    <div class="wrap">
+      <nav aria-label="Primary navigation">
+        <a href="/" class="brand" aria-label="CrownWords home"><span class="logo" aria-hidden="true"></span><strong>CrownWords</strong></a>
+        <div class="nav-links">
+          <a href="/">Home</a>
+          <a href="/projects.html" aria-current="page">Projects</a>
+          <a href="/about.html">About</a>
+          <a href="/contact.html">Contact</a>
+        </div>
+      </nav>
+    </div>
+  </header>
+  <main id="main" class="wrap">
+    <section class="intro" aria-labelledby="projects-title">
+      <div class="eyebrow">David Kwagala · CrownWords</div>
+      <h1 id="projects-title">Faith-led tools for real life.</h1>
+      <p>This growing collection brings together scripture, creativity, stewardship, practical guidance, and technology—built with clarity, purpose, and care.</p>
+    </section>
+    <section class="projects" aria-label="Projects">
+      <article class="card"><h2>CrownWords</h2><p>Daily decrees, declarations, scripture rhythms, and worship words gathered in one focused place.</p></article>
+      <article class="card"><h2>AlphaHub</h2><p>An AI-powered personal ecosystem and creative lab for shaping ideas into useful work.</p></article>
+      <article class="card"><h2>Amos</h2><p>A faith-rooted task and verse companion created to nurture disciplined, God-fearing lives.</p></article>
+      <article class="card"><h2>David Legal App</h2><p>A practical space for legal clarity and documentation, guided by truth, order, and responsible stewardship.</p></article>
+    </section>
+    <section class="principles">
+      <h2>One foundation</h2>
+      <p>Each project serves the CrownWords vision: Word, Wealth, and Worship expressed through technology that is simple, useful, and respectful of the people who use it.</p>
+    </section>
+  </main>
+  <footer><div class="wrap">© <span id="year"></span> CrownWords · Built by David Kwagala</div></footer>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://cxxodj.github.io/</loc><lastmod>2025-10-16</lastmod></url>
   <url><loc>https://cxxodj.github.io/about.html</loc><lastmod>2025-10-16</lastmod></url>
+  <url><loc>https://coxdoj.github.io/projects.html</loc><lastmod>2026-08-23</lastmod></url>
   <url><loc>https://cxxodj.github.io/subscriptions.html</loc><lastmod>2025-10-16</lastmod></url>
   <url><loc>https://cxxodj.github.io/privacy.html</loc><lastmod>2025-10-16</lastmod></url>
   <url><loc>https://cxxodj.github.io/terms.html</loc><lastmod>2025-10-16</lastmod></url>


### PR DESCRIPTION
## What this adds

- a standalone Projects page for CrownWords, AlphaHub, Amos, and David Legal App
- a Projects link in the existing primary navigation
- the new page in the sitemap

## Safety

- keeps the current homepage, Roadmap section, daily CrownWord loader, styling, and deployment workflow intact
- uses a separate branch and draft pull request, so GitHub Pages will not publish the change until this is reviewed and merged into `main`

## Validation

- page serves successfully in a local static preview
- HTML references introduced by this change resolve locally
- repository whitespace checks pass

## Follow-up observations (not changed here)

The existing site has several older broken `/assets/...` references and stale `cxxodj.github.io` metadata. Those should be repaired in a separate pull request to keep this content addition small and easy to review.